### PR TITLE
feat: handle permissions correctly for inviting / kicking

### DIFF
--- a/src/guild/guild_contract.cairo
+++ b/src/guild/guild_contract.cairo
@@ -40,7 +40,9 @@ pub mod GuildComponent {
     impl Guild<
         TContractState, +HasComponent<TContractState>,
     > of interface::IGuild<ComponentState<TContractState>> {
-        fn invite_member(ref self: ComponentState<TContractState>, member: ContractAddress, rank_id: Option<u8>) {
+        fn invite_member(
+            ref self: ComponentState<TContractState>, member: ContractAddress, rank_id: Option<u8>,
+        ) {
             self._only_inviter();
             self._validate_not_member(member);
             let inviter_rank_id = self._get_inviter_rank_id();
@@ -132,7 +134,9 @@ pub mod GuildComponent {
         }
 
         /// Internal: Add a member to the guild with a specific rank
-        fn _add_member_with_rank(ref self: ComponentState<TContractState>, member: ContractAddress, rank_id: u8) {
+        fn _add_member_with_rank(
+            ref self: ComponentState<TContractState>, member: ContractAddress, rank_id: u8,
+        ) {
             let new_member = Member { addr: member, rank_id, is_creator: false };
             self.members.write(member, new_member);
         }
@@ -144,7 +148,9 @@ pub mod GuildComponent {
         }
 
         /// Internal: Validate inviter's rank is higher than the invitee's
-        fn _validate_inviter_rank_higher(self: @ComponentState<TContractState>, inviter_rank_id: u8, invitee_rank_id: u8) {
+        fn _validate_inviter_rank_higher(
+            self: @ComponentState<TContractState>, inviter_rank_id: u8, invitee_rank_id: u8,
+        ) {
             assert!(inviter_rank_id < invitee_rank_id, "Can only invite to a lower rank");
         }
 
@@ -249,7 +255,10 @@ pub mod GuildComponent {
             assert!(target_rank.can_be_kicked, "Target member cannot be kicked");
 
             // Prevent kicking same or higher rank (lower rank_id = higher rank)
-            assert!(member.rank_id < target_member.rank_id, "Cannot kick member with same or higher rank");
+            assert!(
+                member.rank_id < target_member.rank_id,
+                "Cannot kick member with same or higher rank",
+            );
         }
 
         /// Internal: Validate that an address is not already a member
@@ -275,7 +284,9 @@ pub mod GuildComponent {
         }
 
         /// Internal: Resolve the target rank id from Option<u8>, defaulting to lowest
-        fn _resolve_target_rank_id(self: @ComponentState<TContractState>, rank_id: Option<u8>) -> u8 {
+        fn _resolve_target_rank_id(
+            self: @ComponentState<TContractState>, rank_id: Option<u8>,
+        ) -> u8 {
             match rank_id {
                 Option::Some(id) => {
                     self._validate_rank_exists(id);

--- a/src/guild/interface.cairo
+++ b/src/guild/interface.cairo
@@ -3,8 +3,8 @@ use starknet::ContractAddress;
 
 #[starknet::interface]
 pub trait IGuild<TState> {
-    /// Invite a new member with a starting rank.
-    fn invite_member(ref self: TState, member: ContractAddress);
+    /// Invite a new member with a starting rank. If rank_id is None, defaults to the lowest rank.
+    fn invite_member(ref self: TState, member: ContractAddress, rank_id: Option<u8>);
 
     /// Kick a member from the guild.
     fn kick_member(ref self: TState, member: ContractAddress);

--- a/tests/rank_permissions.cairo
+++ b/tests/rank_permissions.cairo
@@ -85,13 +85,8 @@ fn test_owner_can_invite_and_kick() {
     state.initializer(guild_name, rank_name);
     // Owner creates a kickable rank
     state.create_rank(2, true, true, 2, true);
-    let rank_id = state.rank_count.read() - 1_u8;
     // Owner invites BOB
     state.invite_member(BOB);
-    // Set BOB's rank to the kickable rank
-    let mut bob_member = state.members.read(BOB);
-    bob_member.rank_id = rank_id;
-    state.members.write(BOB, bob_member);
     // Owner kicks BOB
     state.kick_member(BOB);
 }
@@ -126,12 +121,8 @@ fn test_member_without_invite_permission_cannot_invite() {
     state.initializer(guild_name, rank_name);
     // Owner creates a new rank with can_invite false
     state.create_rank(2, false, true, 2, true);
-    let rank_id = state.rank_count.read() - 1_u8;
     // Owner invites BOB and assigns him the new rank
     state.invite_member(BOB);
-    let mut bob_member = state.members.read(BOB);
-    bob_member.rank_id = rank_id;
-    state.members.write(BOB, bob_member);
     // BOB tries to invite CHARLIE
     start_cheat_caller_address(test_address(), BOB);
     state.invite_member(CHARLIE);
@@ -146,12 +137,8 @@ fn test_member_without_kick_permission_cannot_kick() {
     state.initializer(guild_name, rank_name);
     // Owner creates a new rank with can_kick false
     state.create_rank(2, true, false, 2, true);
-    let rank_id = state.rank_count.read() - 1_u8;
     // Owner invites BOB and assigns him the new rank
     state.invite_member(BOB);
-    let mut bob_member = state.members.read(BOB);
-    bob_member.rank_id = rank_id;
-    state.members.write(BOB, bob_member);
     // Owner invites CHARLIE
     state.invite_member(CHARLIE);
     // BOB tries to kick CHARLIE
@@ -168,18 +155,11 @@ fn test_cannot_kick_member_with_cannot_be_kicked_rank() {
     state.initializer(guild_name, rank_name);
     // Owner creates a new rank with can_be_kicked false
     state.create_rank(2, true, true, 2, false);
-    let rank_id = state.rank_count.read() - 1_u8;
     // Owner invites BOB and assigns him the new rank
     state.invite_member(BOB);
-    let mut bob_member = state.members.read(BOB);
-    bob_member.rank_id = rank_id;
-    state.members.write(BOB, bob_member);
     // Owner invites CHARLIE
     state.invite_member(CHARLIE);
     // Assign CHARLIE the cannot_be_kicked rank
-    let mut charlie_member = state.members.read(CHARLIE);
-    charlie_member.rank_id = rank_id;
-    state.members.write(CHARLIE, charlie_member);
     // BOB tries to kick CHARLIE
     start_cheat_caller_address(test_address(), BOB);
     state.kick_member(CHARLIE);
@@ -221,12 +201,8 @@ fn test_member_cannot_invite_self() {
     state.initializer(guild_name, rank_name);
     // Owner creates a new rank with can_invite true
     state.create_rank(2, true, true, 2, true);
-    let rank_id = state.rank_count.read() - 1_u8;
     // Owner invites BOB and assigns him the new rank
     state.invite_member(BOB);
-    let mut bob_member = state.members.read(BOB);
-    bob_member.rank_id = rank_id;
-    state.members.write(BOB, bob_member);
     // BOB tries to invite himself
     start_cheat_caller_address(test_address(), BOB);
     state.invite_member(BOB);
@@ -241,12 +217,8 @@ fn test_member_cannot_kick_self() {
     state.initializer(guild_name, rank_name);
     // Owner creates a new rank with can_kick true but can_be_kicked false
     state.create_rank(2, true, true, 2, false);
-    let rank_id = state.rank_count.read() - 1_u8;
     // Owner invites BOB and assigns him the new rank
     state.invite_member(BOB);
-    let mut bob_member = state.members.read(BOB);
-    bob_member.rank_id = rank_id;
-    state.members.write(BOB, bob_member);
     // BOB tries to kick himself
     start_cheat_caller_address(test_address(), BOB);
     state.kick_member(BOB);
@@ -278,11 +250,11 @@ fn test_member_with_invalid_rank_cannot_kick() {
     let rank_name: felt252 = 1;
     state.initializer(guild_name, rank_name);
     // Owner invites BOB and assigns him a non-existent rank
+    state.create_rank(2, true, false, 2, true);
     state.invite_member(BOB);
-    let mut bob_member = state.members.read(BOB);
-    bob_member.rank_id = 250_u8; // non-existent rank
-    state.members.write(BOB, bob_member);
+    
     // Owner invites CHARLIE
+    state.create_rank(3, true, false, 2, true);
     state.invite_member(CHARLIE);
     // BOB tries to kick CHARLIE
     start_cheat_caller_address(test_address(), BOB);
@@ -328,18 +300,11 @@ fn test_member_cannot_kick_same_rank() {
     let rank_name: felt252 = 1;
     state.initializer(guild_name, rank_name);
     // Owner creates a new rank with can_kick true
-    state.create_rank(2, true, true, 2, true);
-    let rank_id = state.rank_count.read() - 1_u8;
+    state.create_rank(2, true, true, 2, true);  
     // Owner invites BOB and assigns him the new rank
     state.invite_member(BOB);
-    let mut bob_member = state.members.read(BOB);
-    bob_member.rank_id = rank_id;
-    state.members.write(BOB, bob_member);
     // Owner invites CHARLIE and assigns him the same rank
     state.invite_member(CHARLIE);
-    let mut charlie_member = state.members.read(CHARLIE);
-    charlie_member.rank_id = rank_id;
-    state.members.write(CHARLIE, charlie_member);
     // BOB tries to kick CHARLIE (same rank)
     start_cheat_caller_address(test_address(), BOB);
     state.kick_member(CHARLIE);

--- a/tests/rank_permissions.cairo
+++ b/tests/rank_permissions.cairo
@@ -252,7 +252,7 @@ fn test_member_with_invalid_rank_cannot_kick() {
     // Owner invites BOB and assigns him a non-existent rank
     state.create_rank(2, true, false, 2, true);
     state.invite_member(BOB, Option::None);
-    
+
     // Owner invites CHARLIE
     state.create_rank(3, true, false, 2, true);
     state.invite_member(CHARLIE, Option::None);
@@ -300,7 +300,7 @@ fn test_member_cannot_kick_same_rank() {
     let rank_name: felt252 = 1;
     state.initializer(guild_name, rank_name);
     // Owner creates a new rank with can_kick true
-    state.create_rank(2, true, true, 2, true);  
+    state.create_rank(2, true, true, 2, true);
     // Owner invites BOB and assigns him the new rank
     state.invite_member(BOB, Option::None);
     // Owner invites CHARLIE and assigns him the same rank

--- a/tests/rank_permissions.cairo
+++ b/tests/rank_permissions.cairo
@@ -86,7 +86,7 @@ fn test_owner_can_invite_and_kick() {
     // Owner creates a kickable rank
     state.create_rank(2, true, true, 2, true);
     // Owner invites BOB
-    state.invite_member(BOB);
+    state.invite_member(BOB, Option::None);
     // Owner kicks BOB
     state.kick_member(BOB);
 }
@@ -100,14 +100,14 @@ fn test_member_with_permission_can_invite_and_kick() {
     // Owner creates a new rank with can_invite and can_kick true
     state.create_rank(2, true, true, 2, true);
 
-    state.invite_member(BOB);
+    state.invite_member(BOB, Option::None);
 
     // Owner creates a worst rank with no permissions
     state.create_rank(3, false, false, 3, true);
 
     start_cheat_caller_address(test_address(), BOB);
     // BOB invites CHARLIE
-    state.invite_member(CHARLIE);
+    state.invite_member(CHARLIE, Option::None);
     // BOB kicks CHARLIE
     state.kick_member(CHARLIE);
 }
@@ -122,10 +122,10 @@ fn test_member_without_invite_permission_cannot_invite() {
     // Owner creates a new rank with can_invite false
     state.create_rank(2, false, true, 2, true);
     // Owner invites BOB and assigns him the new rank
-    state.invite_member(BOB);
+    state.invite_member(BOB, Option::None);
     // BOB tries to invite CHARLIE
     start_cheat_caller_address(test_address(), BOB);
-    state.invite_member(CHARLIE);
+    state.invite_member(CHARLIE, Option::None);
 }
 
 #[test]
@@ -138,9 +138,9 @@ fn test_member_without_kick_permission_cannot_kick() {
     // Owner creates a new rank with can_kick false
     state.create_rank(2, true, false, 2, true);
     // Owner invites BOB and assigns him the new rank
-    state.invite_member(BOB);
+    state.invite_member(BOB, Option::None);
     // Owner invites CHARLIE
-    state.invite_member(CHARLIE);
+    state.invite_member(CHARLIE, Option::None);
     // BOB tries to kick CHARLIE
     start_cheat_caller_address(test_address(), BOB);
     state.kick_member(CHARLIE);
@@ -156,9 +156,9 @@ fn test_cannot_kick_member_with_cannot_be_kicked_rank() {
     // Owner creates a new rank with can_be_kicked false
     state.create_rank(2, true, true, 2, false);
     // Owner invites BOB and assigns him the new rank
-    state.invite_member(BOB);
+    state.invite_member(BOB, Option::None);
     // Owner invites CHARLIE
-    state.invite_member(CHARLIE);
+    state.invite_member(CHARLIE, Option::None);
     // Assign CHARLIE the cannot_be_kicked rank
     // BOB tries to kick CHARLIE
     start_cheat_caller_address(test_address(), BOB);
@@ -174,7 +174,7 @@ fn test_non_member_cannot_invite_or_kick() {
     state.initializer(guild_name, rank_name);
     // ALICE is not a member
     start_cheat_caller_address(test_address(), ALICE);
-    state.invite_member(BOB);
+    state.invite_member(BOB, Option::None);
     // Should panic before this, but also test kick
     state.kick_member(BOB);
 }
@@ -202,10 +202,10 @@ fn test_member_cannot_invite_self() {
     // Owner creates a new rank with can_invite true
     state.create_rank(2, true, true, 2, true);
     // Owner invites BOB and assigns him the new rank
-    state.invite_member(BOB);
+    state.invite_member(BOB, Option::None);
     // BOB tries to invite himself
     start_cheat_caller_address(test_address(), BOB);
-    state.invite_member(BOB);
+    state.invite_member(BOB, Option::None);
 }
 
 #[test]
@@ -218,7 +218,7 @@ fn test_member_cannot_kick_self() {
     // Owner creates a new rank with can_kick true but can_be_kicked false
     state.create_rank(2, true, true, 2, false);
     // Owner invites BOB and assigns him the new rank
-    state.invite_member(BOB);
+    state.invite_member(BOB, Option::None);
     // BOB tries to kick himself
     start_cheat_caller_address(test_address(), BOB);
     state.kick_member(BOB);
@@ -233,13 +233,13 @@ fn test_member_with_invalid_rank_cannot_invite() {
     let rank_name: felt252 = 1;
     state.initializer(guild_name, rank_name);
     // Owner invites BOB and assigns him a non-existent rank
-    state.invite_member(BOB);
-    let mut bob_member = state.members.read(BOB);
-    bob_member.rank_id = 250_u8; // non-existent rank
-    state.members.write(BOB, bob_member);
+    state.create_rank(2, false, false, 2, true);
+    state.invite_member(BOB, Option::None);
+    state.create_rank(3, false, false, 2, true);
+
     // BOB tries to invite CHARLIE
     start_cheat_caller_address(test_address(), BOB);
-    state.invite_member(CHARLIE);
+    state.invite_member(CHARLIE, Option::None);
 }
 
 #[test]
@@ -251,11 +251,11 @@ fn test_member_with_invalid_rank_cannot_kick() {
     state.initializer(guild_name, rank_name);
     // Owner invites BOB and assigns him a non-existent rank
     state.create_rank(2, true, false, 2, true);
-    state.invite_member(BOB);
+    state.invite_member(BOB, Option::None);
     
     // Owner invites CHARLIE
     state.create_rank(3, true, false, 2, true);
-    state.invite_member(CHARLIE);
+    state.invite_member(CHARLIE, Option::None);
     // BOB tries to kick CHARLIE
     start_cheat_caller_address(test_address(), BOB);
     state.kick_member(CHARLIE);
@@ -302,9 +302,9 @@ fn test_member_cannot_kick_same_rank() {
     // Owner creates a new rank with can_kick true
     state.create_rank(2, true, true, 2, true);  
     // Owner invites BOB and assigns him the new rank
-    state.invite_member(BOB);
+    state.invite_member(BOB, Option::None);
     // Owner invites CHARLIE and assigns him the same rank
-    state.invite_member(CHARLIE);
+    state.invite_member(CHARLIE, Option::None);
     // BOB tries to kick CHARLIE (same rank)
     start_cheat_caller_address(test_address(), BOB);
     state.kick_member(CHARLIE);
@@ -321,11 +321,11 @@ fn test_member_cannot_kick_higher_rank() {
     // Owner creates a new rank with can_kick true
     state.create_rank(2, true, true, 2, true);
     // Owner invites BOB and assigns him the lower rank
-    state.invite_member(BOB);
+    state.invite_member(BOB, Option::None);
     // Owner creates a new rank with can_kick true
     state.create_rank(3, true, true, 3, true);
 
-    state.invite_member(CHARLIE);
+    state.invite_member(CHARLIE, Option::None);
 
     start_cheat_caller_address(test_address(), CHARLIE);
     state.kick_member(BOB);

--- a/tests/test_guild.cairo
+++ b/tests/test_guild.cairo
@@ -39,7 +39,8 @@ fn test_guild_invite() {
     let rank_name: felt252 = 1;
     state.initializer(guild_name, rank_name);
 
-    state.invite_member(ALICE);
+    state.create_rank(2, true, true, 2, true);
+    state.invite_member(ALICE, Option::None);
 }
 
 #[test]
@@ -52,7 +53,7 @@ fn test_guild_invite_nonowner() {
 
     start_cheat_caller_address(test_address(), BOB);
 
-    state.invite_member(ALICE);
+    state.invite_member(ALICE, Option::None);
 }
 
 
@@ -63,10 +64,11 @@ fn test_guild_double_invite() {
     let guild_name: felt252 = 1234;
     let rank_name: felt252 = 1;
     state.initializer(guild_name, rank_name);
+    state.create_rank(2, true, true, 2, true);
 
-    state.invite_member(ALICE);
+    state.invite_member(ALICE, Option::None);
 
-    state.invite_member(ALICE);
+    state.invite_member(ALICE, Option::None);
 }
 
 
@@ -80,10 +82,7 @@ fn test_guild_kick() {
     state.create_rank(2, true, true, 2, true);
     let rank_id = state.rank_count.read() - 1_u8;
     // Invite ALICE and assign her the kickable rank
-    state.invite_member(ALICE);
-    let mut alice_member = state.members.read(ALICE);
-    alice_member.rank_id = rank_id;
-    state.members.write(ALICE, alice_member);
+    state.invite_member(ALICE, Option::Some(rank_id));
     state.kick_member(ALICE);
 }
 
@@ -109,10 +108,7 @@ fn test_guild_double_kick() {
     state.create_rank(2, true, true, 2, true);
     let rank_id = state.rank_count.read() - 1_u8;
     // Invite BOB and assign him the kickable rank
-    state.invite_member(BOB);
-    let mut bob_member = state.members.read(BOB);
-    bob_member.rank_id = rank_id;
-    state.members.write(BOB, bob_member);
+    state.invite_member(BOB, Option::Some(rank_id));
     // First kick should succeed
     state.kick_member(BOB);
     // Second kick should fail with "Member does not exist in the guild"


### PR DESCRIPTION
feat: handle permissions correctly for inviting / kicking

fix: the tests and simplify

feat: invite member function lets you include the desired rank

chore: minor refactor