### PR TITLE
chore: clean post-merge cairo formatting and unused imports

### DIFF
--- a/src/gov/governance.cairo
+++ b/src/gov/governance.cairo
@@ -1,5 +1,3 @@
-use starknet::ContractAddress;
-
 #[starknet::interface]
 pub trait IGovernanceWrap<TContractState> {
     fn initializer(ref self: TContractState);
@@ -13,8 +11,6 @@ pub mod GovernanceWrapComponent {
     use openzeppelin_governance::governor::{DefaultConfig, GovernorComponent};
     use openzeppelin_introspection::src5::SRC5Component;
     use openzeppelin_introspection::src5::SRC5Component::InternalImpl as SRC5InternalImpl;
-    use starknet::ContractAddress;
-
     #[storage]
     pub struct Storage {}
 

--- a/src/guild/guild.cairo
+++ b/src/guild/guild.cairo
@@ -8,7 +8,7 @@ pub mod Guild {
         DistributionPolicy, EpochSnapshot, Member, PendingInvite, PluginConfig, RedemptionWindow,
         Role, ShareOffer,
     };
-    use starknet::{ContractAddress, get_caller_address};
+    use starknet::ContractAddress;
     use starknet::storage::{
         StorageMapReadAccess, StoragePointerReadAccess, StoragePointerWriteAccess,
     };

--- a/src/mocks/guild.cairo
+++ b/src/mocks/guild.cairo
@@ -1,5 +1,3 @@
-use starknet::ContractAddress;
-
 /// Minimal mock contract for testing the v0.2 GuildComponent.
 /// Only embeds the GuildComponent — no ERC20 or Governor.
 #[starknet::contract]

--- a/src/token/guild_token.cairo
+++ b/src/token/guild_token.cairo
@@ -76,8 +76,8 @@ pub mod GuildToken {
                     contract.inactive_balance.write(0);
                 }
             }
-            if recipient != Zero::zero() && contract.inactivity_flags.read(recipient).flagged_at > 0
-            {
+            if recipient != Zero::zero()
+                && contract.inactivity_flags.read(recipient).flagged_at > 0 {
                 contract.inactive_balance.write(contract.inactive_balance.read() + amount);
             }
 


### PR DESCRIPTION
## Summary
- apply Cairo formatter output introduced by merge/rebase drift
- remove unused imports in governance and mock modules to keep warnings focused
- keep contract and SDK verification green after cleanup