### PR TITLE
test: replace deprecated contract_address_const helpers

### DIFF
--- a/tests/test_guild_governor.cairo
+++ b/tests/test_guild_governor.cairo
@@ -1,5 +1,6 @@
 use core::num::traits::Zero;
 use core::serde::Serde;
+use guilds::tests::constants::AsAddressTrait;
 use openzeppelin_interfaces::governance::extensions::{
     IGovernorSettingsAdminDispatcher, IGovernorSettingsAdminDispatcherTrait,
     IQuorumFractionDispatcher, IQuorumFractionDispatcherTrait,
@@ -22,19 +23,19 @@ pub trait IGuildGovernorView<TState> {
 }
 
 fn TOKEN_HOLDER() -> ContractAddress {
-    starknet::contract_address_const::<0x300>()
+    0x300.as_address()
 }
 
 fn VOTER() -> ContractAddress {
-    starknet::contract_address_const::<0x400>()
+    0x400.as_address()
 }
 
 fn GUILD_ADDR() -> ContractAddress {
-    starknet::contract_address_const::<0x200>()
+    0x200.as_address()
 }
 
 fn TOKEN_GOVERNOR_ADDR() -> ContractAddress {
-    starknet::contract_address_const::<0x100>()
+    0x100.as_address()
 }
 
 fn BASE_TS() -> u64 {

--- a/tests/test_guild_token.cairo
+++ b/tests/test_guild_token.cairo
@@ -1,5 +1,6 @@
 use core::serde::Serde;
 use guilds::interfaces::token::{IGuildTokenDispatcher, IGuildTokenDispatcherTrait};
+use guilds::tests::constants::AsAddressTrait;
 use openzeppelin_interfaces::erc20::{
     IERC20Dispatcher, IERC20DispatcherTrait, IERC20MetadataDispatcher,
     IERC20MetadataDispatcherTrait,
@@ -12,27 +13,27 @@ use snforge_std::{
 use starknet::ContractAddress;
 
 fn HOLDER() -> ContractAddress {
-    starknet::contract_address_const::<0x111>()
+    0x111.as_address()
 }
 
 fn GOVERNOR() -> ContractAddress {
-    starknet::contract_address_const::<0x222>()
+    0x222.as_address()
 }
 
 fn GUILD() -> ContractAddress {
-    starknet::contract_address_const::<0x333>()
+    0x333.as_address()
 }
 
 fn ALICE() -> ContractAddress {
-    starknet::contract_address_const::<0x444>()
+    0x444.as_address()
 }
 
 fn BOB() -> ContractAddress {
-    starknet::contract_address_const::<0x555>()
+    0x555.as_address()
 }
 
 fn CHARLIE() -> ContractAddress {
-    starknet::contract_address_const::<0x666>()
+    0x666.as_address()
 }
 
 fn BASE_TS() -> u64 {

--- a/tests/test_lifecycle.cairo
+++ b/tests/test_lifecycle.cairo
@@ -5,6 +5,7 @@ use guilds::guild::guild_contract::GuildComponent::InternalImpl;
 use guilds::mocks::guild::GuildMock;
 use guilds::models::constants::ActionType;
 use guilds::models::types::{Member, PendingInvite, Role};
+use guilds::tests::constants::AsAddressTrait;
 use snforge_std::{start_cheat_block_timestamp, start_cheat_caller_address, test_address};
 use starknet::ContractAddress;
 use starknet::storage::{
@@ -13,27 +14,27 @@ use starknet::storage::{
 };
 
 fn FOUNDER() -> ContractAddress {
-    starknet::contract_address_const::<0x100>()
+    0x100.as_address()
 }
 
 fn GOVERNOR() -> ContractAddress {
-    starknet::contract_address_const::<0x200>()
+    0x200.as_address()
 }
 
 fn TOKEN() -> ContractAddress {
-    starknet::contract_address_const::<0x300>()
+    0x300.as_address()
 }
 
 fn ALICE() -> ContractAddress {
-    starknet::contract_address_const::<0x400>()
+    0x400.as_address()
 }
 
 fn BOB() -> ContractAddress {
-    starknet::contract_address_const::<0x500>()
+    0x500.as_address()
 }
 
 fn CHARLIE() -> ContractAddress {
-    starknet::contract_address_const::<0x600>()
+    0x600.as_address()
 }
 
 type TestState = GuildMock::ContractState;

--- a/tests/test_permissions.cairo
+++ b/tests/test_permissions.cairo
@@ -4,6 +4,7 @@ use guilds::guild::guild_contract::GuildComponent::InternalImpl;
 use guilds::mocks::guild::GuildMock;
 use guilds::models::constants::ActionType;
 use guilds::models::types::{Member, Role};
+use guilds::tests::constants::AsAddressTrait;
 use snforge_std::{start_cheat_caller_address, test_address};
 use starknet::ContractAddress;
 use starknet::storage::{
@@ -16,23 +17,23 @@ use starknet::storage::{
 // ========================================================================
 
 fn FOUNDER() -> ContractAddress {
-    starknet::contract_address_const::<0x100>()
+    0x100.as_address()
 }
 
 fn GOVERNOR() -> ContractAddress {
-    starknet::contract_address_const::<0x200>()
+    0x200.as_address()
 }
 
 fn TOKEN() -> ContractAddress {
-    starknet::contract_address_const::<0x300>()
+    0x300.as_address()
 }
 
 fn ALICE() -> ContractAddress {
-    starknet::contract_address_const::<0x400>()
+    0x400.as_address()
 }
 
 fn BOB() -> ContractAddress {
-    starknet::contract_address_const::<0x500>()
+    0x500.as_address()
 }
 
 type TestState = GuildMock::ContractState;


### PR DESCRIPTION
## Summary
- replace deprecated starknet::contract_address_const usages in integration tests
- switch to AsAddressTrait helper for deterministic test addresses
- keep contract and SDK verification green