### PR TITLE
chore(example-client): ignore generated tsbuildinfo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ sdk/node_modules/
 sdk/dist/
 examples/web-client/node_modules/
 examples/web-client/dist/
+examples/web-client/*.tsbuildinfo

--- a/examples/web-client/tsconfig.tsbuildinfo
+++ b/examples/web-client/tsconfig.tsbuildinfo
@@ -1,1 +1,0 @@
-{"root":["./src/App.tsx","./src/main.tsx","./src/sdk/client.ts"],"version":"5.9.3"}


### PR DESCRIPTION
## Summary
- ignore generated TypeScript build info files for web-client example
- remove accidentally tracked 